### PR TITLE
Removes DataProvider in favor of PredefinedSplits

### DIFF
--- a/mim/cross_validation.py
+++ b/mim/cross_validation.py
@@ -1,33 +1,29 @@
+from mim.extractors.extractor import Container
 from mim.util.logs import get_logger
 
 log = get_logger('Cross Validation')
 
 
-# class CrossValidationWrapper:
-#     def __init__(self, cv_type, **cv_args):
-#         pass
-#
-#     def split(self, data: Container):
-#         x = data.index
-#         y = data['y'].as_numpy
-#         groups = data.groups
-#         for train, val in self.cv.split(x, y=y, groups=groups):
-#             yield data.split(train, val)
+class CrossValidationWrapper:
+    def __init__(self, cv):
+        self.cv = cv
+
+    def split(self, data: Container):
+        x = data.index
+        y = data['y'].as_numpy
+
+        groups = data.groups
+        for train, val in self.cv.split(x, y=y, groups=groups):
+            yield data.split(train, val)
 
 
-# class DataProvider:
-#
-#     def train_val_split(self):
-#         raise NotImplementedError
-#
+class ChronologicalSplit:
+    def __init__(self, test_size=0.5):
+        self.test_size = test_size
 
-# class ChronologicalSplit:
-#     def __init__(self, test_size=0.5):
-#         self.test_size = test_size
-#
-#     def split(self, x, y=None, groups=None):
-#         n = len(x)
-#         k = int((1 - self.test_size) * n)
-#         train = list(range(k))
-#         test = list(range(k, n))
-#         yield train, test
+    def split(self, x, y=None, groups=None):
+        n = len(x)
+        k = int((1 - self.test_size) * n)
+        train = list(range(k))
+        test = list(range(k, n))
+        yield train, test

--- a/mim/experiments/ab_glucose.py
+++ b/mim/experiments/ab_glucose.py
@@ -2,19 +2,26 @@
 
 from enum import Enum
 from os.path import join
+
 import tensorflow as tf
+from sklearn.model_selection import KFold
 
 from mim.experiments.experiments import Experiment
 from mim.config import GLUCOSE_ROOT
 from mim.extractors.ab_json import ABJSONExtractor
 import mim.models.ab_nn as ab_nn
 
+TRAIN_FILE = join(GLUCOSE_ROOT, "hbg+lund-train.json.gz")
+VAL_FILE = join(GLUCOSE_ROOT, "hbg+lund-dev.json.gz")
+TEST_FILE = join(GLUCOSE_ROOT, "hbg+lund-test.json.gz")
+
 BASE_EXTRACTOR_KWARGS: dict = {
-        "index": {"train": join(GLUCOSE_ROOT, "hbg+lund-train.json.gz"),
-                  "val": join(GLUCOSE_ROOT, "hbg+lund-dev.json.gz"),
-                  "test": join(GLUCOSE_ROOT, "hbg+lund-test.json.gz")},
-        "labels": {"target": "label-index+30d-ami+death-30d"},
-    }
+    "index": {
+        "train_files": [TRAIN_FILE],
+        "val_files": [VAL_FILE],
+    },
+    "labels": {"target": "label-index+30d-ami+death-30d"},
+}
 
 
 def copy_update_dict(base_dict: dict, updates: dict) -> dict:
@@ -30,10 +37,10 @@ class ABGlucose(Experiment, Enum):
         model=ab_nn.ab_simple_lr,
         extractor=ABJSONExtractor,
         extractor_kwargs=copy_update_dict(BASE_EXTRACTOR_KWARGS, {
-            "features": {"gender",
-                         "age",
-                         "bl-Glukos", "bl-TnT", "bl-Krea", "bl-Hb"}
+            "features": {"gender", "age", "bl-Glukos", "bl-TnT", "bl-Krea",
+                         "bl-Hb"}
         }),
+        use_predefined_splits=True,
         building_model_requires_development_data=True,
         ignore_callbacks=False,
         model_kwargs={},
@@ -43,9 +50,29 @@ class ABGlucose(Experiment, Enum):
             'name': tf.keras.optimizers.SGD,
             'kwargs': {'learning_rate': 1}
         },
-        data_provider_kwargs={
-            "mode": "train_val"
-        }
+    )
+
+    EXAMPLE_USING_KFOLD_ON_VAL_TEST = KERAS_LR_BLOOD_BL._replace(
+        description="Small example showing how to use a different data set.",
+        extractor_kwargs=copy_update_dict(
+            BASE_EXTRACTOR_KWARGS,
+            {
+                "features": {
+                    "gender",
+                    "age",
+                    "bl-Glukos",
+                    "bl-TnT",
+                    "bl-Krea",
+                    "bl-Hb"
+                },
+                "index": {
+                    "train_files": [VAL_FILE, TEST_FILE]
+                }
+            }
+        ),
+        cv=KFold,
+        cv_kwargs={'num_folds': 5},
+        use_predefined_splits=False
     )
 
     ECG_BEAT = Experiment(
@@ -58,6 +85,7 @@ class ABGlucose(Experiment, Enum):
                          "bl-Glukos", "bl-TnT", "bl-Krea", "bl-Hb",
                          "ecg_beat_8"}
         }),
+        use_predefined_splits=True,
         building_model_requires_development_data=True,
         ignore_callbacks=False,
         model_kwargs={
@@ -76,8 +104,5 @@ class ABGlucose(Experiment, Enum):
         optimizer={
             'name': tf.keras.optimizers.Adam,
             'kwargs': {'learning_rate': 0.003}
-        },
-        data_provider_kwargs={
-            "mode": "train_val"
         }
     )

--- a/mim/experiments/hyper_experiments.py
+++ b/mim/experiments/hyper_experiments.py
@@ -8,6 +8,7 @@ from mim.experiments.experiments import Experiment
 from mim.experiments.search_strategies import Hyperband, RandomSearch
 from mim.models.simple_nn import basic_cnn3, super_basic_cnn
 from mim.extractors.esc_trop import EscTrop
+from mim.cross_validation import ChronologicalSplit
 from mim.util.logs import get_logger
 from mim.util.util import callable_to_string
 
@@ -55,14 +56,18 @@ class HyperSearch(HyperExperiment, Enum):
             description="Experiment using variations of a basic CNN for "
                         "predicing MACE using a single ECG record.",
             extractor=EscTrop,
-            features={
-                'ecg_mode': 'beat',
-                'ecgs': ['index']
+            extractor_kwargs={
+                'features': {
+                    'ecg_mode': 'beat',
+                    'ecgs': ['index']
+                },
+                'index': {},
             },
-            index={},
 
             model=basic_cnn3,
             building_model_requires_development_data=True,
+            cv=ChronologicalSplit,
+            cv_kwargs={'test_size': 1 / 3},
             optimizer={
                 'name': hp.Choice([
                     tf.keras.optimizers.Adam,
@@ -106,13 +111,17 @@ class HyperSearch(HyperExperiment, Enum):
             description="Experiment using very simple cnn, testing different "
                         "learning rates, batch sizes and dropout rates.",
             extractor=EscTrop,
-            features={
-                'ecg_mode': 'beat',
-                'ecgs': ['index']
+            extractor_kwargs={
+                'features': {
+                    'ecg_mode': 'beat',
+                    'ecgs': ['index']
+                },
+                'index': {},
             },
-            index={},
             model=super_basic_cnn,
             building_model_requires_development_data=True,
+            cv=ChronologicalSplit,
+            cv_kwargs={'test_size': 1 / 3},
             optimizer={
                 'name': tf.keras.optimizers.Adam,
                 'kwargs': {
@@ -143,13 +152,17 @@ class HyperSearch(HyperExperiment, Enum):
             description="Experiment using very simple cnn, testing different "
                         "filters, kernel sizes and pool sizes.",
             extractor=EscTrop,
-            features={
-                'ecg_mode': 'beat',
-                'ecgs': ['index']
+            extractor_kwargs={
+                'features': {
+                    'ecg_mode': 'beat',
+                    'ecgs': ['index']
+                },
+                'index': {},
             },
-            index={},
             model=super_basic_cnn,
             building_model_requires_development_data=True,
+            cv=ChronologicalSplit,
+            cv_kwargs={'test_size': 1 / 3},
             optimizer={
                 'name': tf.keras.optimizers.Adam,
                 'kwargs': {'learning_rate': 3e-4}

--- a/mim/experiments/multiple_ecgs.py
+++ b/mim/experiments/multiple_ecgs.py
@@ -5,6 +5,7 @@ from sklearn.metrics import roc_auc_score
 from mim.experiments.experiments import Experiment
 from mim.extractors.esc_trop import EscTrop
 from mim.models.simple_nn import basic_cnn
+from mim.cross_validation import ChronologicalSplit
 
 
 # Here's an attempt at a structure for experiment names:
@@ -36,7 +37,14 @@ class MultipleECG(Experiment, Enum):
             },
             "index": {}
         },
+        building_model_requires_development_data=True,
+        cv=ChronologicalSplit,
+        cv_kwargs={'test_size': 1/3},
         scoring=roc_auc_score,
+    )
+
+    FOO = ESC_B1_MACE30_BCNN2_V1._replace(
+        description='Foo'
     )
 
     # AB: Shouldn't this jsut be a copy of the above experiment, with the

--- a/mim/extractors/esc_trop.py
+++ b/mim/extractors/esc_trop.py
@@ -1,10 +1,10 @@
 from mim.massage.esc_trop import make_ed_table, make_troponin_table
-from mim.extractors.extractor import Data, Container, ECGData, Extractor, \
-    DataProvider, SingleContainerLinearSplitProvider
+from mim.extractors.extractor import Data, Container, ECGData, Extractor
+from mim.cross_validation import CrossValidationWrapper, ChronologicalSplit
 
 
 class EscTrop(Extractor):
-    def get_data_provider(self, dp_kwargs) -> DataProvider:
+    def get_data(self) -> Container:
         ed = make_ed_table()
         tnt = make_troponin_table()
         ed = ed.join(tnt).reset_index()
@@ -47,4 +47,8 @@ class EscTrop(Extractor):
             fits_in_memory=self.fits_in_memory
         )
 
-        return SingleContainerLinearSplitProvider(data, **dp_kwargs)
+        hold_out_splitter = CrossValidationWrapper(
+            ChronologicalSplit(test_size=1/4)
+        )
+        dev, _ = next(hold_out_splitter.split(data))
+        return dev

--- a/mim/extractors/expect.py
+++ b/mim/extractors/expect.py
@@ -4,8 +4,7 @@ import pandas as pd
 from tensorflow import float64
 from sklearn.preprocessing import OrdinalEncoder
 
-from mim.extractors.extractor import Data, Container, Extractor, \
-    SingleContainerLinearSplitProvider
+from mim.extractors.extractor import Data, Container, Extractor
 
 CHARLSON_FEATURES = [
     "Charlson-AcuteMyocardialInfarction",
@@ -43,7 +42,7 @@ ORDINAL_FEATURES = CHARLSON_FEATURES[:-1] + PREVIOUS_CONDITIONS + ['gender']
 
 
 class Expect(Extractor):
-    def get_data_provider(self, dp_kwargs):
+    def get_data(self):
         data = self._parse_json()
         x = self._extract_features(data)
         y = self._extract_labels(data)
@@ -56,7 +55,7 @@ class Expect(Extractor):
             },
             index=index
         )
-        return SingleContainerLinearSplitProvider(data, **dp_kwargs)
+        return data
 
     def _parse_json(self):
         path = '/home/sapfo/andersb/ekg_share/json_data/12tnt/hbg+lund-split/'

--- a/mim/fakes/fake_extractors.py
+++ b/mim/fakes/fake_extractors.py
@@ -1,8 +1,7 @@
 from sklearn.datasets import make_classification
 from tensorflow import float64
 
-from mim.extractors.extractor import Container, Data, Extractor, \
-    DataProvider, SingleContainerLinearSplitProvider
+from mim.extractors.extractor import Container, Data, Extractor
 
 
 class FakeExtractor(Extractor):
@@ -13,18 +12,16 @@ class FakeExtractor(Extractor):
         else:
             self.mc_kwargs = {}
 
-    def get_data_provider(self, dp_kwargs) -> DataProvider:
+    def get_data(self) -> Container:
         x, y = make_classification(**self.mc_kwargs)
         index = range(len(x))
         x = Data(x, index=index, dtype=float64)
         y = Data(y, index=index, dtype=float64)
-        # c = Container.from_dict({'x': x, 'y': y})
-        c = Container({'x': x, 'y': y})
-        return SingleContainerLinearSplitProvider(c, **dp_kwargs)
+        return Container({'x': x, 'y': y})
 
 
 class FakeECG(Extractor):
-    def get_data_provider(self, dp_kwargs) -> DataProvider:
+    def get_data(self,) -> Container:
         rows, cols = self.index['shape']
         n_features = rows * cols
         n_samples = self.index['n_samples']
@@ -45,4 +42,4 @@ class FakeECG(Extractor):
             'y': Data(y)
         })
 
-        return SingleContainerLinearSplitProvider(c, **dp_kwargs)
+        return c

--- a/tests/fakes/test_fake_extractors.py
+++ b/tests/fakes/test_fake_extractors.py
@@ -3,20 +3,21 @@ from mim.fakes.fake_extractors import FakeExtractor
 
 
 def test_data_is_correct_format():
-    dp = FakeExtractor().get_data_provider({})
-    data = dp.get_set("all")
+    data = FakeExtractor().get_data()
     assert isinstance(data, Data)
     assert data['x'].as_numpy.shape == (100, 20)
     assert data['y'].as_numpy.shape == (100,)
 
 
 def test_can_specify_inputs():
-    ext = FakeExtractor(**{"index": dict(n_samples=10,
-                                         n_features=5,
-                                         n_informative=3)})
-    dp = ext.get_data_provider({})
-    data = dp.get_set("all")
-
+    ext = FakeExtractor(
+        index=dict(
+            n_samples=10,
+            n_features=5,
+            n_informative=3
+        )
+    )
+    data = ext.get_data()
     assert data['x'].as_numpy.shape == (10, 5)
 
 
@@ -31,8 +32,5 @@ def test_can_specify_inputs_like_experiment():
         labels=labels,
         processing=processing
     )
-    dp = FakeExtractor(**extractors_kwargs).get_data_provider({})
-
-    data = dp.get_set("all")
-
+    data = FakeExtractor(**extractors_kwargs).get_data()
     assert data['x'].as_numpy.shape == (10, 5)

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -4,8 +4,8 @@ from mim.fakes.fake_extractors import FakeExtractor
 
 class TestModel:
     def test_rf_binary_classification_output_is_one_dimensional(self):
-        dp = FakeExtractor().get_data_provider({})
-        data = dp.get_set("all")
+        data = FakeExtractor().get_data()
+        # data = dp.get_set("all")
         clf = mw.RandomForestClassifier(n_estimators=10)
         clf.fit(data)
         assert clf.only_last_prediction_column_is_used
@@ -14,10 +14,10 @@ class TestModel:
         assert 1 == len(prediction.columns)
 
     def test_rf_multiclass_classification_output_is_multi_dimensional(self):
-        dp = FakeExtractor(
+        data = FakeExtractor(
             **{"index": dict(n_informative=3, n_classes=3)}
-        ).get_data_provider({})
-        data = dp.get_set("all")
+        ).get_data()
+        # data = dp.get_set("all")
         clf = mw.RandomForestClassifier(n_estimators=10)
         clf.fit(data)
         assert not clf.only_last_prediction_column_is_used


### PR DESCRIPTION
The Data object now comes with an optional attribute that defines
predefined splits to use for making cross-validation splits (or just
regular train/val split as a special case). The Extractor class is
responsible for defining the splits to use. If the Data has predefined
splits, we can then set a flag that will use those splits instead of
regular cross-validation.